### PR TITLE
修正翻译

### DIFF
--- a/docs/standard/library-guidance/sourcelink.md
+++ b/docs/standard/library-guidance/sourcelink.md
@@ -21,7 +21,7 @@ SourceLink 是一种允许从 NuGet 由开发人员的.NET 程序集的源代码
 
 ## <a name="using-sourcelink"></a>使用 SourceLink
 
-使用SourceLink的说明可以在[dotnet/sourceLink](https://github.com/dotnet/sourcelink/blob/master/README.md) GitHub 存储库中找到。
+可以在 [dotnet/sourceLink](https://github.com/dotnet/sourcelink/blob/master/README.md) GitHub 存储库中找到使用 SourceLink 的说明。
 
 可以使用[NuGet 包资源管理器](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer)确认 SourceLink 元数据已成功嵌入包中。 检查`Repository`元数据是否存在具有注释标识符和.pdb 文件位于与每个目标的.dll。
 

--- a/docs/standard/library-guidance/sourcelink.md
+++ b/docs/standard/library-guidance/sourcelink.md
@@ -21,7 +21,7 @@ SourceLink 是一种允许从 NuGet 由开发人员的.NET 程序集的源代码
 
 ## <a name="using-sourcelink"></a>使用 SourceLink
 
-可以上找到用于使用 SourceLink 说明[dotnet/sourceLink](https://github.com/dotnet/sourcelink/blob/master/README.md) GitHub 存储库。
+使用SourceLink的说明可以在[dotnet/sourceLink](https://github.com/dotnet/sourcelink/blob/master/README.md) GitHub 存储库中找到。
 
 可以使用[NuGet 包资源管理器](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer)确认 SourceLink 元数据已成功嵌入包中。 检查`Repository`元数据是否存在具有注释标识符和.pdb 文件位于与每个目标的.dll。
 


### PR DESCRIPTION
“Instructions for using SourceLink can be found on the dotnet/sourceLink GitHub repository.”
翻译为“可以上找到用于使用 SourceLink 说明dotnet/sourceLink GitHub 存储库。”
修改为“使用SourceLink的说明可以在dotnet/sourceLink GitHub 存储库中找到。”