### PR TITLE
记忆->内存

### DIFF
--- a/docs/standard/garbage-collection/fundamentals.md
+++ b/docs/standard/garbage-collection/fundamentals.md
@@ -96,7 +96,7 @@ ms.locfileid: "50982862"
 ## <a name="the-managed-heap"></a>托管堆  
  在垃圾回收器由 CLR 初始化之后，它会分配一段内存用于存储和管理对象。 此内存称为托管堆（与操作系统中的本机堆相对）。  
   
- 每个托管进程都有一个托管堆。 进程中的所有线程都在同一堆上分配对象记忆。  
+ 每个托管进程都有一个托管堆。 进程中的所有线程都在同一堆上为对象分配内存。  
   
  若要保留内存，垃圾回收器将调用 Win32 [VirtualAlloc](https://msdn.microsoft.com/library/aa366887.aspx) 函数，并且每次会为托管应用程序保留一个内存段。 垃圾回收器还会根据需要保留段，并通过调用 Win32 [VirtualFree](https://msdn.microsoft.com/library/aa366892.aspx) 函数将段释放回操作系统（在清除所有对象的段之后）。  
   


### PR DESCRIPTION
All threads in the process allocate memory for objects on the same heap
翻译成“进程中的所有线程都在同一堆上分配对象记忆”
改成“进程中的所有线程都在同一堆上为对象分配内存”