### PR TITLE
修改Solution下的目录名称翻译： “数据” -> “Data”

### DIFF
--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -99,7 +99,7 @@ ms.locfileid: "53149648"
 
 2. 在项目中创建一个名为“数据”的目录来保存数据集文件：
 
-    在“解决方案资源管理器”中，右键单击项目，然后选择“添加” > “新文件夹”。 键入“数据”，然后按 Enter。
+    在“解决方案资源管理器”中，右键单击项目，然后选择“添加” > “新文件夹”。 键入“Data”，然后按 Enter。
 
 3. 安装“Microsoft.ML NuGet 包”：
 
@@ -107,7 +107,7 @@ ms.locfileid: "53149648"
 
 ### <a name="prepare-your-data"></a>准备数据
 
-1. 下载 [WikiPedia detox-250-line-data.tsv](https://github.com/dotnet/machinelearning/blob/master/test/data/wikipedia-detox-250-line-data.tsv) 和 [wikipedia-detox-250-line-test.tsv](https://github.com/dotnet/machinelearning/blob/master/test/data/wikipedia-detox-250-line-test.tsv) 数据集并将它们保存到先前创建的“数据”文件夹。 第一个数据集定型机器学习模型，第二个数据集可用来评估模型的准确度。
+1. 下载 [WikiPedia detox-250-line-data.tsv](https://github.com/dotnet/machinelearning/blob/master/test/data/wikipedia-detox-250-line-data.tsv) 和 [wikipedia-detox-250-line-test.tsv](https://github.com/dotnet/machinelearning/blob/master/test/data/wikipedia-detox-250-line-test.tsv) 数据集并将它们保存到先前创建的“Data”文件夹。 第一个数据集定型机器学习模型，第二个数据集可用来评估模型的准确度。
 
 2. 在“解决方案资源管理器”中，右键单击每个 \*.tsv 文件，然后选择“属性”。 在“高级”下，将“复制到输出目录”的值更改为“如果较新则复制”。
 


### PR DESCRIPTION
在Solution中创建“Data”目录，这个“Data”是目录名称，没必要翻译成中文“数据”，因为后面的代码中路径会用到 "..\Data\.."。 这里如果翻译成中文会给后面的示例代码阅读造成困惑。