### PR TITLE
Fix：'run out of work' typo error translation

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/index.md
+++ b/docs/csharp/programming-guide/concepts/async/index.md
@@ -116,7 +116,7 @@ string urlContents = await client.GetStringAsync("https://docs.microsoft.com");
   
 5.  `DoIndependentWork` 是完成其工作并返回其调用方的同步方法。  
   
-6.  `AccessTheWebAsync` 已用完工作，可以不受 `getStringTask` 的结果影响。 接下来，`AccessTheWebAsync` 需要计算并返回该下载字符串的长度，但该方法仅在具有字符串时才能计算该值。  
+6.  `AccessTheWebAsync` 已运行完毕，可以不受 `getStringTask` 的结果影响。 接下来，`AccessTheWebAsync` 需要计算并返回该下载字符串的长度，但该方法仅在具有字符串时才能计算该值。  
   
      因此，`AccessTheWebAsync` 使用一个 await 运算符来挂起其进度，并把控制权交给调用 `AccessTheWebAsync` 的方法。 `AccessTheWebAsync` 将 `Task<int>` 返回给调用方。 该任务表示对产生下载字符串长度的整数结果的一个承诺。  
   


### PR DESCRIPTION
'run out of work' should be here meaning '运行完毕' or '完成'. '用完工作' doesn't seem a native Chinese saying.