### PR TITLE
Fix small code reference error in csharp-7.yml

### DIFF
--- a/docs/csharp/tutorials/exploration/csharp-7.yml
+++ b/docs/csharp/tutorials/exploration/csharp-7.yml
@@ -202,7 +202,7 @@ items:
     为了修改返回的引用，需要将 `ref` 修饰符添加到局部变量声明中，并在调用 `Find` 之前，使变量在返回值为引用时成为引用。 修改浏览器中的测试代码以匹配以下内容：
 
 
-    [!code-csharp[EverythingByValue](~/samples/snippets/csharp/new-in-7/MatrixSearch.cs#TestByValue "test code for return object by reference")]
+    [!code-csharp[EverythingByValue](~/samples/snippets/csharp/new-in-7/MatrixSearch.cs#SnippetTestByRef "test code for return object by reference")]
 
 
     现在，上例中的第二个 `WriteLine` 语句打印出值 `24`，指示矩阵中的存储已被修改。 局部变量已使用 `ref` 修饰符进行声明，它将返回 `ref`。 必须在声明时初始化 `ref` 变量，不能拆分声明和初始化。

--- a/docs/csharp/tutorials/exploration/csharp-7.yml
+++ b/docs/csharp/tutorials/exploration/csharp-7.yml
@@ -202,7 +202,7 @@ items:
     为了修改返回的引用，需要将 `ref` 修饰符添加到局部变量声明中，并在调用 `Find` 之前，使变量在返回值为引用时成为引用。 修改浏览器中的测试代码以匹配以下内容：
 
 
-    [!code-csharp[EverythingByValue](~/samples/snippets/csharp/new-in-7/MatrixSearch.cs#SnippetTestByRef "test code for return object by reference")]
+    [!code-csharp[EverythingByValue](~/samples/snippets/csharp/new-in-7/MatrixSearch.cs#SnippetTestByRef "引用的返回对象的测试代码")]
 
 
     现在，上例中的第二个 `WriteLine` 语句打印出值 `24`，指示矩阵中的存储已被修改。 局部变量已使用 `ref` 修饰符进行声明，它将返回 `ref`。 必须在声明时初始化 `ref` 变量，不能拆分声明和初始化。


### PR DESCRIPTION
I find small a code reference error when I read this [tutorial](https://docs.microsoft.com/zh-cn/dotnet/csharp/tutorials/exploration/csharp-7?tutorial-step=5)

![a wrong code example](https://user-images.githubusercontent.com/20439262/59412195-7b7cfe00-8def-11e9-86f3-3fc9d10ccd31.png)

this actually not the `ref` workable example, I checkout the source code and update link to `~/samples/snippets/csharp/new-in-7/MatrixSearch.cs` right part