### PR TITLE
修正 lambda-expressions.md 的标题

### DIFF
--- a/docs/csharp/language-reference/operators/lambda-expressions.md
+++ b/docs/csharp/language-reference/operators/lambda-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Lambda 表达式 - C# 引用
+title: Lambda 表达式 - C# 参考
 description: 了解 Lambda 表达式。 存在表达式作为其主体的表达式 Lambda，或语句块作为其主体的语句 Lambda。
 ms.date: 09/25/2020
 helpviewer_keywords:
@@ -16,7 +16,7 @@ ms.contentlocale: zh-CN
 ms.lasthandoff: 11/12/2020
 ms.locfileid: "94556837"
 ---
-# <a name="lambda-expressions-c-reference"></a>Lambda 表达式（C# 引用）
+# <a name="lambda-expressions-c-reference"></a>Lambda 表达式（C# 参考）
 
 “Lambda 表达式”是采用以下任意一种形式的表达式：
 


### PR DESCRIPTION
lambda-expressions.md 的标题中"引用"应翻译为"参考"

建议的有用信息：
1.请参阅[快速入门本地化样式指南](https://docs.microsoft.com/globalization/localization/styleguides)，了解 Microsoft 风格指南中**最重要的十大规则**。
2.请参阅 [Microsoft 语言门户](https://www.microsoft.com/language)，查看各 Microsoft 产品的**标准化术语翻译**。
